### PR TITLE
fix(local): nginx WS upgrade + /api/live/* relay block so voice works…

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,3 +1,10 @@
+# Map `Upgrade` header so /api/live/relay/{bridge_id} can carry WebSocket frames
+# from the browser to the FastAPI chat container (Gemini Live voice).
+map $http_upgrade $gvp_connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -21,9 +28,31 @@ server {
     location /api/chat {
         proxy_pass http://chat:8000;
         proxy_http_version 1.1;
+        # WS upgrade headers are cheap on plain HTTP requests (no Upgrade header
+        # arrives) and required if anything under /api/chat ever upgrades.
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $gvp_connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Gemini Live voice: POST /api/live/session (HTTP) + /api/live/relay/{id}
+    # (WebSocket). Same upstream as /api/chat. Long-lived: disable buffering and
+    # extend read/send timeouts so a quiet voice session doesn't get killed at
+    # nginx's default 60s.
+    location /api/live/ {
+        proxy_pass http://chat:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $gvp_connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_read_timeout 1d;
+        proxy_send_timeout 1d;
     }
 }


### PR DESCRIPTION
… in docker-compose

The local stack (docker-compose proxy=nginx, chat=FastAPI) couldn't actually relay Gemini Live WebSockets, even though the chat container's Dockerfile defaults to CHAT_LIVE_RELAY=1: nginx had no Upgrade/Connection headers on /api/chat and no /api/live/relay/* location at all, so the browser → nginx → chat WS handshake silently failed and the FE surfaced the same "voice needs WebSocket relay" error operators see in production.

Three changes in docker/nginx.conf:
- New http-level `map $http_upgrade $gvp_connection_upgrade` so plain HTTP requests get `Connection: close` and real upgrades get `Connection: upgrade` (the standard idiomatic pattern; setting `Connection "upgrade"` literally on non-WS requests pins them to a broken state on some clients).
- /api/chat location: pass Upgrade + $gvp_connection_upgrade. Cheap on the POST /api/chat path; needed if anything under that prefix ever upgrades.
- New /api/live/ location: proxy_pass to the chat container with the upgrade headers, plus proxy_buffering off and 1d read/send timeouts so a quiet voice session isn't killed at nginx's default 60s. Covers both POST /api/live/session and WS /api/live/relay/{bridge_id}.

Production note: this fix is for `docker-compose up` development only. Real prod still requires deploying chat on ECS/ALB and pointing gvp:chat-api-url at the ECS host — `bash scripts/integrate-and-deploy.sh prod` with CHAT_ECS_CLUSTER_PROD + CHAT_ECS_SERVICE_PROD set picks this up automatically; the readiness banner at the end of the script reports the final state.