### PR TITLE
feat(infra): SAM-managed ECS chat stack so browser voice works on stage

### DIFF
--- a/aws/chat-ecs-template.yaml
+++ b/aws/chat-ecs-template.yaml
@@ -1,0 +1,366 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  Portfolio chat — Fargate behind an ALB so browser voice (Gemini Live)
+  works. API Gateway HTTP API + Lambda (aws/chat-template.yaml) cannot
+  upgrade browser WebSockets, so this stack is the long-lived host that
+  runs the same FastAPI container with CHAT_LIVE_RELAY=1.
+
+Parameters:
+  StageName:
+    Type: String
+    AllowedValues: [stage, prod]
+    Default: stage
+    Description: >
+      Deploy environment suffix. Used in resource names and tags. Resource
+      logical names stay constant; the suffix differentiates stacks in the
+      same account/region.
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC to launch the ECS service and ALB in. Default VPC works for stage.
+
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: >
+      Public subnets (>=2, different AZs) for the ALB and the Fargate tasks.
+      Tasks need outbound internet to reach Gemini; public subnets with
+      AssignPublicIp=ENABLED is the simplest setup.
+
+  ImageUri:
+    Type: String
+    Description: >
+      Full ECR image URI with tag (e.g.
+      123456789012.dkr.ecr.us-east-2.amazonaws.com/gvp-chat:stage-abc1234).
+      Changing this triggers a new TaskDefinition revision + rolling deploy.
+
+  GeminiApiKey:
+    Type: String
+    NoEcho: true
+    MinLength: 1
+    Description: >
+      Google AI Studio / Gemini API key. NoEcho. For production, prefer
+      Secrets Manager + the task definition's `Secrets` block; this stack
+      passes it as a container env for simplicity.
+
+  ChatCorsOrigins:
+    Type: String
+    Default: 'https://chat.marwanelgendy.link,https://marwanelgendy.link,https://www.marwanelgendy.link'
+    Description: >
+      Comma-separated CHAT_CORS_ORIGINS for the FastAPI app's CORS + the WS
+      origin allow-list. Include every browser origin that loads the chat UI.
+
+  ChatTranscriptsTableName:
+    Type: String
+    Default: ''
+    Description: >
+      DynamoDB table for transcript persistence (output from the contact
+      stack: ChatTranscriptsTableName). Empty disables persistence.
+
+  GeminiModel:
+    Type: String
+    Default: gemini-3.1-flash-lite
+  GeminiFallbackModel:
+    Type: String
+    Default: gemma-4-26b-a4b-it
+  GeminiLiveModel:
+    Type: String
+    Default: gemini-3.1-flash-live-preview
+  ChatVoiceModel:
+    Type: String
+    Default: ''
+
+  ContainerCpu:
+    Type: Number
+    Default: 256
+    AllowedValues: [256, 512, 1024]
+  ContainerMemory:
+    Type: Number
+    Default: 512
+    AllowedValues: [512, 1024, 2048]
+  DesiredCount:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    MaxValue: 4
+  ContainerPort:
+    Type: Number
+    Default: 8000
+
+  CertificateArn:
+    Type: String
+    Default: ''
+    Description: >
+      Optional ACM cert ARN for HTTPS:443 listener. When empty, the ALB
+      listens on HTTP:80 — mixed-content blocks browsers on HTTPS sites, so
+      leave this empty only for ALB-DNS smoke tests, not for the real site.
+
+  AlbLogBucket:
+    Type: String
+    Default: ''
+    Description: Optional S3 bucket for ALB access logs (empty disables).
+
+Conditions:
+  HasCertificate: !Not [!Equals [!Ref CertificateArn, '']]
+  HasTranscriptsTable: !Not [!Equals [!Ref ChatTranscriptsTableName, '']]
+  HasAlbLogs: !Not [!Equals [!Ref AlbLogBucket, '']]
+
+Resources:
+  # --- Networking ---
+  AlbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub chat-${StageName} ALB ingress
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - !If
+          - HasCertificate
+          - IpProtocol: tcp
+            FromPort: 443
+            ToPort: 443
+            CidrIp: 0.0.0.0/0
+            Description: HTTPS from internet
+          - IpProtocol: tcp
+            FromPort: 80
+            ToPort: 80
+            CidrIp: 0.0.0.0/0
+            Description: HTTP from internet (no cert)
+      Tags:
+        - { Key: gvp:stage, Value: !Ref StageName }
+
+  TaskSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub chat-${StageName} ECS task ingress (from ALB only)
+      VpcId: !Ref VpcId
+      Tags:
+        - { Key: gvp:stage, Value: !Ref StageName }
+
+  TaskSgIngressFromAlb:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref TaskSecurityGroup
+      SourceSecurityGroupId: !Ref AlbSecurityGroup
+      IpProtocol: tcp
+      FromPort: !Ref ContainerPort
+      ToPort: !Ref ContainerPort
+      Description: Container port from ALB
+
+  # --- IAM ---
+  TaskExecutionRole:
+    # Used by ECS agent for image pull + CloudWatch logs. Not the running app's identity.
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Service: ecs-tasks.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  TaskRole:
+    # Identity the running app uses (boto3 → DynamoDB transcripts).
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Service: ecs-tasks.amazonaws.com }
+            Action: sts:AssumeRole
+      Policies:
+        - !If
+          - HasTranscriptsTable
+          - PolicyName: TranscriptsWrite
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - dynamodb:PutItem
+                    - dynamodb:UpdateItem
+                  Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ChatTranscriptsTableName}
+          - !Ref AWS::NoValue
+
+  # --- Logging ---
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /gvp/chat-${StageName}
+      RetentionInDays: 30
+
+  # --- ECS ---
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub gvp-chat-${StageName}
+      ClusterSettings:
+        - Name: containerInsights
+          Value: disabled
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub gvp-chat-${StageName}
+      NetworkMode: awsvpc
+      RequiresCompatibilities: [FARGATE]
+      Cpu: !Ref ContainerCpu
+      Memory: !Ref ContainerMemory
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ContainerDefinitions:
+        - Name: chat
+          Image: !Ref ImageUri
+          Essential: true
+          PortMappings:
+            - { ContainerPort: !Ref ContainerPort, Protocol: tcp }
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: chat
+          Environment:
+            - { Name: CHAT_PROVIDER, Value: gemini }
+            - { Name: CHAT_LIVE_RELAY, Value: '1' }
+            - { Name: CHAT_CORS_ORIGINS, Value: !Ref ChatCorsOrigins }
+            - { Name: GEMINI_API_KEY, Value: !Ref GeminiApiKey }
+            - { Name: GEMINI_MODEL, Value: !Ref GeminiModel }
+            - { Name: GEMINI_FALLBACK_MODEL, Value: !Ref GeminiFallbackModel }
+            - { Name: GEMINI_LIVE_MODEL, Value: !Ref GeminiLiveModel }
+            - { Name: CHAT_VOICE_MODEL, Value: !Ref ChatVoiceModel }
+            - { Name: CHAT_TRANSCRIPTS_TABLE, Value: !Ref ChatTranscriptsTableName }
+            - { Name: AWS_REGION, Value: !Ref AWS::Region }
+
+  # --- ALB ---
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub gvp-chat-${StageName}
+      Scheme: internet-facing
+      Type: application
+      Subnets: !Ref SubnetIds
+      SecurityGroups: [!Ref AlbSecurityGroup]
+      IpAddressType: ipv4
+      LoadBalancerAttributes:
+        - { Key: idle_timeout.timeout_seconds, Value: '300' }
+        - !If
+          - HasAlbLogs
+          - { Key: access_logs.s3.enabled, Value: 'true' }
+          - !Ref AWS::NoValue
+        - !If
+          - HasAlbLogs
+          - { Key: access_logs.s3.bucket, Value: !Ref AlbLogBucket }
+          - !Ref AWS::NoValue
+      Tags:
+        - { Key: gvp:stage, Value: !Ref StageName }
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub gvp-chat-${StageName}
+      VpcId: !Ref VpcId
+      Protocol: HTTP
+      Port: !Ref ContainerPort
+      TargetType: ip
+      HealthCheckPath: /health
+      HealthCheckProtocol: HTTP
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+      Matcher: { HttpCode: '200' }
+      TargetGroupAttributes:
+        # Long-lived WS streams need a generous deregistration delay so in-flight
+        # voice turns drain instead of being killed mid-stream on deploy.
+        - { Key: deregistration_delay.timeout_seconds, Value: '60' }
+        - { Key: stickiness.enabled, Value: 'false' }
+
+  ListenerHttps:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: HasCertificate
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Protocol: HTTPS
+      Port: 443
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+  ListenerHttp:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    # When a cert is provided, also stand up HTTP:80 → 301 → HTTPS:443 (good hygiene).
+    # When no cert, HTTP:80 forwards to the target group (DNS-only smoke testing).
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Protocol: HTTP
+      Port: 80
+      DefaultActions:
+        - !If
+          - HasCertificate
+          - Type: redirect
+            RedirectConfig:
+              Protocol: HTTPS
+              Port: '443'
+              Host: '#{host}'
+              Path: '/#{path}'
+              Query: '#{query}'
+              StatusCode: HTTP_301
+          - Type: forward
+            TargetGroupArn: !Ref TargetGroup
+
+  Service:
+    Type: AWS::ECS::Service
+    # Make sure the listener is up before ECS tries to register tasks behind it.
+    DependsOn: [ListenerHttp, TaskSgIngressFromAlb]
+    Properties:
+      ServiceName: !Sub gvp-chat-${StageName}
+      Cluster: !Ref Cluster
+      LaunchType: FARGATE
+      TaskDefinition: !Ref TaskDefinition
+      DesiredCount: !Ref DesiredCount
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          Subnets: !Ref SubnetIds
+          SecurityGroups: [!Ref TaskSecurityGroup]
+      LoadBalancers:
+        - ContainerName: chat
+          ContainerPort: !Ref ContainerPort
+          TargetGroupArn: !Ref TargetGroup
+      HealthCheckGracePeriodSeconds: 60
+      PropagateTags: SERVICE
+      Tags:
+        - { Key: gvp:stage, Value: !Ref StageName }
+
+Outputs:
+  ClusterName:
+    Description: ECS cluster name (export as CHAT_ECS_CLUSTER_* for the deploy script)
+    Value: !Ref Cluster
+  ServiceName:
+    Description: ECS service name (export as CHAT_ECS_SERVICE_* for the deploy script)
+    Value: !GetAtt Service.Name
+  AlbDnsName:
+    Description: ALB DNS name (point a Route53 alias here; or use directly for smoke tests)
+    Value: !GetAtt LoadBalancer.DNSName
+  ChatBaseUrl:
+    Description: Resolved chat base URL (https when cert provided, else http)
+    Value: !If
+      - HasCertificate
+      - !Sub https://${LoadBalancer.DNSName}
+      - !Sub http://${LoadBalancer.DNSName}
+  TaskRoleArn:
+    Value: !GetAtt TaskRole.Arn
+  LogGroupName:
+    Value: !Ref LogGroup

--- a/scripts/integrate-and-deploy.sh
+++ b/scripts/integrate-and-deploy.sh
@@ -296,8 +296,81 @@ if [[ -n "${CHAT_ECR_REPOSITORY_URI:-}" && "${run_chat_docker}" == "true" ]]; th
   docker push "${REMOTE_SHA}"
   docker push "${REMOTE_LATEST}"
 
-  CLUSTER="${CHAT_ECS_CLUSTER}"
-  SERVICE="${CHAT_ECS_SERVICE}"
+  # ---- Optional: SAM-managed ECS chat stack (aws/chat-ecs-template.yaml) ----
+  # When CHAT_ECS_SAM_STACK_NAME_<ENV> is set we deploy/update the ECS+ALB stack
+  # with the freshly-pushed image. The stack update creates a new TaskDefinition
+  # revision and CloudFormation rolls the service. Outputs ClusterName/ServiceName
+  # are exported so the existing ALB-DNS auto-derive below still works unchanged.
+  CHAT_ECS_SAM_STACK_NAME=""
+  CHAT_ECS_CERT_ARN=""
+  CHAT_ECS_ALB_LOG_BUCKET=""
+  if [[ "${DEPLOY_ENV}" == "stage" ]]; then
+    CHAT_ECS_SAM_STACK_NAME="${CHAT_ECS_SAM_STACK_NAME_STAGE:-}"
+    CHAT_ECS_CERT_ARN="${CHAT_ECS_CERT_ARN_STAGE:-${CHAT_ECS_CERT_ARN:-}}"
+    CHAT_ECS_ALB_LOG_BUCKET="${CHAT_ECS_ALB_LOG_BUCKET_STAGE:-${CHAT_ECS_ALB_LOG_BUCKET:-}}"
+  else
+    CHAT_ECS_SAM_STACK_NAME="${CHAT_ECS_SAM_STACK_NAME_PROD:-}"
+    CHAT_ECS_CERT_ARN="${CHAT_ECS_CERT_ARN_PROD:-${CHAT_ECS_CERT_ARN:-}}"
+    CHAT_ECS_ALB_LOG_BUCKET="${CHAT_ECS_ALB_LOG_BUCKET_PROD:-${CHAT_ECS_ALB_LOG_BUCKET:-}}"
+  fi
+
+  if [[ -n "${CHAT_ECS_SAM_STACK_NAME}" ]]; then
+    if [[ -z "${CHAT_ECS_VPC_ID:-}" || -z "${CHAT_ECS_SUBNET_IDS:-}" ]]; then
+      echo "ERROR: CHAT_ECS_SAM_STACK_NAME_${DEPLOY_ENV} is set but CHAT_ECS_VPC_ID / CHAT_ECS_SUBNET_IDS are missing." >&2
+      echo "       Set both before re-running. See secrets.example/chat-deploy.env.example." >&2
+      exit 1
+    fi
+    if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+      echo "ERROR: GEMINI_API_KEY required for chat-ecs SAM deploy." >&2
+      exit 1
+    fi
+    echo "sam deploy chat-ecs stack=${CHAT_ECS_SAM_STACK_NAME} env=${DEPLOY_ENV} image=${REMOTE_SHA}"
+    sam deploy \
+      --template-file "${AWS_DIR}/chat-ecs-template.yaml" \
+      --stack-name "${CHAT_ECS_SAM_STACK_NAME}" \
+      --region "${REGION}" \
+      --capabilities CAPABILITY_IAM \
+      --no-confirm-changeset \
+      --no-fail-on-empty-changeset \
+      --resolve-s3 \
+      --s3-prefix "${CHAT_ECS_SAM_STACK_NAME}" \
+      --parameter-overrides \
+        "StageName=${DEPLOY_ENV}" \
+        "VpcId=${CHAT_ECS_VPC_ID}" \
+        "SubnetIds=${CHAT_ECS_SUBNET_IDS}" \
+        "ImageUri=${REMOTE_SHA}" \
+        "GeminiApiKey=${GEMINI_API_KEY}" \
+        "GeminiModel=${GEMINI_MODEL:-gemini-3.1-flash-lite}" \
+        "GeminiFallbackModel=${GEMINI_FALLBACK_MODEL:-gemma-4-26b-a4b-it}" \
+        "GeminiLiveModel=${GEMINI_LIVE_MODEL:-gemini-3.1-flash-live-preview}" \
+        "ChatVoiceModel=${CHAT_VOICE_MODEL:-}" \
+        "ChatCorsOrigins=${CHAT_CORS_ORIGINS:-https://chat.marwanelgendy.link,https://marwanelgendy.link,https://www.marwanelgendy.link}" \
+        "ChatTranscriptsTableName=${CHAT_TRANSCRIPTS_TABLE_NAME:-}" \
+        "CertificateArn=${CHAT_ECS_CERT_ARN}" \
+        "AlbLogBucket=${CHAT_ECS_ALB_LOG_BUCKET}"
+
+    # Read outputs and feed back into the existing CHAT_ECS_CLUSTER / _SERVICE
+    # vars so the ALB-DNS discovery further down works without extra config.
+    _ECS_OUTPUTS_JSON="$(aws cloudformation describe-stacks \
+      --stack-name "${CHAT_ECS_SAM_STACK_NAME}" \
+      --region "${REGION}" \
+      --query 'Stacks[0].Outputs' \
+      --output json 2>/dev/null || echo '[]')"
+    _ECS_CLUSTER_FROM_STACK="$(echo "${_ECS_OUTPUTS_JSON}" | python3 -c "import json,sys; xs=json.load(sys.stdin); print(next((x['OutputValue'] for x in xs if x['OutputKey']=='ClusterName'),''))" 2>/dev/null || true)"
+    _ECS_SERVICE_FROM_STACK="$(echo "${_ECS_OUTPUTS_JSON}" | python3 -c "import json,sys; xs=json.load(sys.stdin); print(next((x['OutputValue'] for x in xs if x['OutputKey']=='ServiceName'),''))" 2>/dev/null || true)"
+    if [[ -n "${_ECS_CLUSTER_FROM_STACK}" && -n "${_ECS_SERVICE_FROM_STACK}" ]]; then
+      CHAT_ECS_CLUSTER="${_ECS_CLUSTER_FROM_STACK}"
+      CHAT_ECS_SERVICE="${_ECS_SERVICE_FROM_STACK}"
+      echo "chat-ecs outputs: cluster=${CHAT_ECS_CLUSTER} service=${CHAT_ECS_SERVICE}"
+    fi
+    # When SAM owns the service, the CloudFormation update already rolled the
+    # TaskDefinition. Skip the legacy aws-ecs-update-service path below.
+    CLUSTER=""
+    SERVICE=""
+  else
+    CLUSTER="${CHAT_ECS_CLUSTER}"
+    SERVICE="${CHAT_ECS_SERVICE}"
+  fi
 
   if [[ -n "${CLUSTER}" && -n "${SERVICE}" ]]; then
     echo "ECS force deploy cluster=${CLUSTER} service=${SERVICE}"
@@ -308,7 +381,7 @@ if [[ -n "${CHAT_ECR_REPOSITORY_URI:-}" && "${run_chat_docker}" == "true" ]]; th
       --region "${REGION}" \
       --no-cli-pager
     echo "note: ECS chat image defaults CHAT_LIVE_RELAY=1 (docker/chat/Dockerfile). gvp:chat-api-url is patched from CHAT_*_CHAT_API_URL when set, else derived from this ECS service’s ALB/NLB DNS when CHAT_ECS_AUTO_SYNC_CHAT_URL is enabled."
-  else
+  elif [[ -z "${CHAT_ECS_SAM_STACK_NAME}" ]]; then
     echo "CHAT_ECS_CLUSTER_* / CHAT_ECS_SERVICE_* unset — skip ECS roll (image pushed)."
   fi
 elif [[ "${CHAT_ALWAYS_BUILD:-0}" == "1" ]]; then

--- a/secrets.example/chat-deploy.env.example
+++ b/secrets.example/chat-deploy.env.example
@@ -70,3 +70,28 @@ export AWS_REGION=us-east-2
 # export CHAT_ECS_SERVICE_STAGE=gvp-chat-staging
 # export CHAT_ECS_CLUSTER_PROD=my-prod-cluster
 # export CHAT_ECS_SERVICE_PROD=gvp-chat-prod
+
+# --- SAM-managed ECS chat stack (aws/chat-ecs-template.yaml) ---
+# When CHAT_ECS_SAM_STACK_NAME_<ENV> is set, integrate-and-deploy.sh deploys/updates
+# the full Fargate + ALB + IAM + SG + log-group stack with the freshly-pushed image.
+# CloudFormation rolls the service automatically (no manual aws ecs update-service).
+# CHAT_ECS_CLUSTER/SERVICE outputs are read from the stack — you don't need to set
+# CHAT_ECS_CLUSTER_<ENV> / CHAT_ECS_SERVICE_<ENV> when using SAM-managed ECS.
+#
+# Prerequisites (set in the same .secrets/chat-deploy.env):
+#   - CHAT_ECR_REPOSITORY_URI   — must already exist (create with `aws ecr create-repository`)
+#   - GEMINI_API_KEY            — required (passed as a NoEcho stack parameter)
+#   - CHAT_ECS_VPC_ID           — VPC to deploy into (default VPC works for stage)
+#   - CHAT_ECS_SUBNET_IDS       — comma-separated public subnets (>=2 AZs) for ALB+tasks
+# Optional:
+#   - CHAT_ECS_CERT_ARN_STAGE / _PROD — ACM cert ARN for HTTPS:443 listener.
+#     Strongly recommended for prod: HTTPS sites block mixed-content fetch/WS to HTTP ALB.
+#   - CHAT_ECS_ALB_LOG_BUCKET_STAGE / _PROD — S3 bucket for ALB access logs (empty disables).
+#
+# export CHAT_ECS_SAM_STACK_NAME_STAGE=gvp-chat-ecs-stage
+# export CHAT_ECS_SAM_STACK_NAME_PROD=gvp-chat-ecs-prod
+# export CHAT_ECS_VPC_ID=vpc-0123456789abcdef0
+# export CHAT_ECS_SUBNET_IDS=subnet-aaa,subnet-bbb
+# export CHAT_ECS_CERT_ARN_STAGE=arn:aws:acm:us-east-2:111122223333:certificate/abcd
+# export CHAT_ECS_CERT_ARN_PROD=arn:aws:acm:us-east-2:111122223333:certificate/efgh
+# export CHAT_ECS_ALB_LOG_BUCKET_STAGE=my-alb-logs-stage


### PR DESCRIPTION
API Gateway HTTP API + Lambda can't upgrade browser WebSockets, so the live voice agent has been silently impossible on stage even after enabling GVP_CHAT_VOICE=1. This adds the missing piece: a SAM template that stands up a long-lived Fargate service behind an ALB running the same FastAPI chat container with CHAT_LIVE_RELAY=1 (the Dockerfile default), and wires it into integrate-and-deploy.sh.

aws/chat-ecs-template.yaml — new stack
  Resources:
    - ECS cluster + Fargate Service (1 task default, sized 256 CPU / 512 MB, DeploymentCircuitBreaker + Rollback enabled)
    - TaskDefinition with the chat container env (GEMINI_API_KEY, CORS, transcripts table, voice model overrides; CHAT_LIVE_RELAY=1 by default from the image)
    - ApplicationLoadBalancer (internet-facing) + TargetGroup (HTTP, /health, 60s deregistration delay so in-flight WS turns drain on rollover)
    - HTTPS:443 listener when CertificateArn is provided (TLS 1.3), HTTP:80 redirect to HTTPS; HTTP:80 forwarder when no cert (smoke testing only)
    - Two security groups: ALB ingress from internet, task ingress from ALB only
    - IAM execution role (ECR pull, CloudWatch) + task role (DynamoDB Put/Update on the transcripts table when provided)
    - 30-day CloudWatch log group Outputs ClusterName / ServiceName / AlbDnsName / ChatBaseUrl so the deploy script and the auto-derive logic find everything without extra env.

scripts/integrate-and-deploy.sh — opt-in via CHAT_ECS_SAM_STACK_NAME_<ENV>
  When set, the script (after ECR image push):
    1. sam deploy chat-ecs-template.yaml with ImageUri=${REMOTE_SHA} so the stack update triggers a new TaskDefinition revision and CloudFormation rolls the service — no separate aws ecs update-service needed.
    2. Reads Outputs.ClusterName / ServiceName from the stack and feeds them into CHAT_ECS_CLUSTER / CHAT_ECS_SERVICE so the existing ALB-DNS auto-derive (lines ~318-365) reuses them unchanged.
    3. Validates pre-reqs (VPC ID, subnet IDs, GEMINI_API_KEY) and exits with a clear error message naming the env vars to set when any is missing.
    4. Skips the legacy aws ecs update-service path when SAM owns the service. When CHAT_ECS_SAM_STACK_NAME_<ENV> is unset, behavior is unchanged.

secrets.example/chat-deploy.env.example — documents the new env block
  CHAT_ECS_SAM_STACK_NAME_<ENV>, CHAT_ECS_VPC_ID, CHAT_ECS_SUBNET_IDS,
  CHAT_ECS_CERT_ARN_<ENV>, CHAT_ECS_ALB_LOG_BUCKET_<ENV>. Calls out the
  HTTPS recommendation for prod (mixed-content blocks browsers from HTTPS
  sites to HTTP ALB).

Verified: aws cloudformation validate-template passes; sam validate --lint passes; bash -n on the script passes.

Next step for the operator: set the prereqs in .secrets/chat-deploy.env, set CHAT_ECS_SAM_STACK_NAME_STAGE=gvp-chat-ecs-stage, and re-run `bash scripts/integrate-and-deploy.sh stage`. The readiness banner at the end will report status: OK once the stack is up.