### PR TITLE
move playground under portfolio

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1079,9 +1079,11 @@ body:not(.content-open) section#home {
     margin-top: 2rem;
 }
 
-#playgroundContent > .playground-intro {
+/* Playground subsection intro paragraph — same role and styling as the portfolio
+ * intro, just for the personal builds block at the bottom of the portfolio page. */
+#portfolioContent > .playground-intro {
     max-width: 44rem;
-    margin: clamp(3rem, 10vh, 5rem) auto 0;
+    margin: clamp(2.5rem, 8vh, 4rem) auto 0;
     padding: 0 1.25rem;
     text-align: center;
     font-family: var(--font-body);
@@ -1090,12 +1092,11 @@ body:not(.content-open) section#home {
     color: var(--text-muted);
 }
 
-#playgroundContent > .playground-intro + section#projects {
+#portfolioContent > .playground-intro + section#projects {
     margin-top: 2rem;
 }
 
-#portfolioContent,
-#playgroundContent {
+#portfolioContent {
     z-index: 50;
 }
 
@@ -2495,13 +2496,8 @@ h6 {
 /* Per-section accent shifts.
    Scoped to `main` so the chrome (nav, footer, chat launcher) keeps the base
    theme accent — only in-content links / focus rings / read-more pick up the
-   playground (warmer) or portfolio (deeper) variant. Subtle by design. */
-[data-theme="space"] body[data-section="playground"] main {
-    --accent: #e08c4a;
-    --accent-hover: #f0a25e;
-    --link-color: #f0b88a;
-    --link-hover: var(--accent-hover);
-}
+   portfolio variant. Subtle by design. (The former 'playground' section was
+   folded into portfolio, so its accent block was removed.) */
 [data-theme="space"] body[data-section="portfolio"] main {
     --accent: #6a98e8;
     --accent-hover: #82adf0;
@@ -2509,12 +2505,6 @@ h6 {
     --link-hover: var(--accent-hover);
 }
 
-[data-theme="garden"] body[data-section="playground"] main {
-    --accent: #9a6328;
-    --accent-hover: #b07a3a;
-    --link-color: #6b3f12;
-    --link-hover: var(--accent-hover);
-}
 [data-theme="garden"] body[data-section="portfolio"] main {
     --accent: #144a2a;
     --accent-hover: #1f6b3d;
@@ -2522,12 +2512,6 @@ h6 {
     --link-hover: var(--accent-hover);
 }
 
-[data-theme="studio"] body[data-section="playground"] main {
-    --accent: #b8593a;
-    --accent-hover: #cf6e4d;
-    --link-color: #8e3f23;
-    --link-hover: var(--accent-hover);
-}
 [data-theme="studio"] body[data-section="portfolio"] main {
     --accent: #2f3f63;
     --accent-hover: #43577f;

--- a/index.html
+++ b/index.html
@@ -58,7 +58,6 @@
             </div>
             <div class="navbar-right">
                 <a href="#portfolio" id="portfolioNav">Portfolio</a>
-                <a href="#playground" id="playgroundNav">Playground</a>
             </div>
         </nav>
     </header>
@@ -182,13 +181,6 @@
                         </div>
                     </div>
                 </section>
-                <div id="playgroundContent" class="hidden">
-                    <p class="playground-intro">Personal builds and explorations. Production habits on a smaller canvas — skills, speed, honest scope.</p>
-                    <section id="projects" class="hidden section-invisible">
-                        <h3 class="section-label">Playground</h3>
-                        <!-- Projects rendered dynamically -->
-                    </section>
-                </div>
                 <div id="portfolioContent" class="hidden">
                     <div class="portfolio-intro experience-summary" aria-labelledby="portfolioWorkLabel">
                         <p id="portfolioWorkLabel" class="section-label experience-summary__label">My work</p>
@@ -201,6 +193,11 @@
                         <!-- Projects rendered dynamically -->
                     </section>
                     <p class="portfolio-earlier-career">Earlier: Software Development Manager at Sunrise Resorts, embedded Linux systems at OIG Electronics, and web and game development at 5D Agency — 2011–2016.</p>
+                    <p class="playground-intro">Personal builds and explorations. Production habits on a smaller canvas — skills, speed, honest scope.</p>
+                    <section id="projects" class="hidden section-invisible">
+                        <h3 class="section-label">Playground</h3>
+                        <!-- Projects rendered dynamically -->
+                    </section>
                 </div>
 
             </div>

--- a/js/app.js
+++ b/js/app.js
@@ -249,29 +249,29 @@ document.addEventListener('DOMContentLoaded', async () => {
       currentSection = state
       if (spaceman) {
         spaceman.setState(state)
-        if (state !== 'playground' && state !== 'portfolio') {
+        if (state !== 'portfolio') {
           spaceman.setContext(null)
         }
       }
       if (spacemanPosition) {
         spacemanPosition.updatePosition()
       }
-      if (state === 'playground' || state === 'portfolio') {
+      if (state === 'portfolio') {
         collapseChatDialog()
       }
       syncChatLaunchers(state)
     }
   })
 
-  // Load and render project data
+  // Load and render project data. Both arrays render into the portfolio
+  // section now — playground is a subsection under portfolio, not its own page.
   const data = await loadProjects('/data/projects.json')
   if (data.loadFailed) {
     showProjectsLoadSiteBanner()
-    renderProjectsSectionError('playgroundContent')
     renderProjectsSectionError('portfolioContent')
   } else {
-    renderProjects('playgroundContent', data.playground, 'projects')
     renderProjects('portfolioContent', data.portfolio, 'portfolioProjects')
+    renderProjects('portfolioContent', data.playground, 'projects')
   }
   initProjectDetailDialog()
 

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -15,9 +15,7 @@ export function initNavigation(options = {}) {
 
   const elements = {
     portfolioNav: document.getElementById('portfolioNav'),
-    playgroundNav: document.getElementById('playgroundNav'),
     homeNav: document.getElementById('homeNav'),
-    playgroundContent: document.getElementById('playgroundContent'),
     portfolioContent: document.getElementById('portfolioContent'),
     projects: document.getElementById('projects'),
     portfolioProjects: document.getElementById('portfolioProjects')
@@ -25,9 +23,7 @@ export function initNavigation(options = {}) {
 
   const navRequired = [
     'homeNav',
-    'playgroundNav',
     'portfolioNav',
-    'playgroundContent',
     'portfolioContent',
     'projects',
     'portfolioProjects'
@@ -43,9 +39,7 @@ export function initNavigation(options = {}) {
     state.section = nextSection
     document.body.classList.toggle('content-open', nextSection !== 'home')
     document.body.dataset.section = nextSection
-    if (nextSection === 'playground') {
-      goPlay(elements, event)
-    } else if (nextSection === 'portfolio') {
+    if (nextSection === 'portfolio') {
       goPortfolio(elements, event)
     } else {
       goHome(elements, event)
@@ -61,9 +55,8 @@ export function initNavigation(options = {}) {
 
   function navigateByHash() {
     const hash = window.location.hash
-    if (hash === '#playground') {
-      applySection('playground', null, true)
-    } else if (hash === '#portfolio') {
+    // Treat legacy '#playground' bookmarks as portfolio so old links keep working.
+    if (hash === '#portfolio' || hash === '#playground') {
       applySection('portfolio', null, true)
     } else {
       applySection('home', null, true)
@@ -74,12 +67,6 @@ export function initNavigation(options = {}) {
     e.preventDefault()
     history.replaceState(null, '', '#portfolio')
     applySection('portfolio', e, true)
-  })
-
-  elements.playgroundNav?.addEventListener('click', (e) => {
-    e.preventDefault()
-    history.replaceState(null, '', '#playground')
-    applySection('playground', e, true)
   })
 
   elements.homeNav?.addEventListener('click', (e) => {
@@ -94,15 +81,12 @@ export function initNavigation(options = {}) {
 }
 
 function goHome(el, event) {
-  if (!el?.projects || !el?.portfolioProjects || !el?.playgroundContent || !el?.portfolioContent) return
+  if (!el?.projects || !el?.portfolioProjects || !el?.portfolioContent) return
   window.scrollTo({ top: 0, behavior: 'smooth' })
   el.projects.classList.remove('content-section-reveal')
   el.portfolioProjects.classList.remove('content-section-reveal')
-  el.playgroundContent.classList.remove('visible')
-  el.playgroundContent.classList.add('hidden')
   el.projects.classList.remove('visible')
   el.projects.classList.add('hidden')
-  el.playgroundNav.classList.remove('section-invisible')
   el.portfolioNav.classList.remove('section-invisible')
   el.homeNav.classList.add('section-invisible')
   el.projects.classList.add('section-invisible')
@@ -113,48 +97,21 @@ function goHome(el, event) {
   if (event) trackClick(event)
 }
 
-function goPlay(el, event) {
-  if (!el?.projects || !el?.portfolioProjects || !el?.playgroundContent || !el?.portfolioContent) return
-  window.scrollTo({ top: 0, behavior: 'smooth' })
-  el.portfolioProjects.classList.remove('content-section-reveal')
-  el.projects.classList.remove('content-section-reveal')
-  el.portfolioContent.classList.remove('visible')
-  el.portfolioContent.classList.add('hidden')
-  el.portfolioProjects.classList.remove('visible')
-  el.portfolioProjects.classList.add('hidden')
-
-  el.playgroundContent.classList.remove('hidden')
-  el.playgroundContent.classList.add('visible')
-  el.playgroundNav.classList.add('section-invisible')
-  el.portfolioNav.classList.remove('section-invisible')
-  el.homeNav.classList.remove('section-invisible')
-
-  el.projects.classList.remove('section-invisible')
-  el.projects.classList.remove('hidden')
-  el.projects.classList.add('visible', 'content-section-reveal')
-
-  if (event) trackClick(event)
-}
-
 function goPortfolio(el, event) {
-  if (!el?.projects || !el?.portfolioProjects || !el?.playgroundContent || !el?.portfolioContent) return
+  if (!el?.projects || !el?.portfolioProjects || !el?.portfolioContent) return
   window.scrollTo({ top: 0, behavior: 'smooth' })
-  el.projects.classList.remove('content-section-reveal')
-  el.portfolioProjects.classList.remove('content-section-reveal')
-  el.playgroundContent.classList.remove('visible')
-  el.playgroundContent.classList.add('hidden')
-  el.projects.classList.remove('visible')
-  el.projects.classList.add('hidden')
 
   el.portfolioContent.classList.remove('hidden')
   el.portfolioContent.classList.add('visible')
   el.portfolioNav.classList.add('section-invisible')
   el.homeNav.classList.remove('section-invisible')
-  el.playgroundNav.classList.remove('section-invisible')
 
-  el.portfolioProjects.classList.remove('section-invisible')
-  el.portfolioProjects.classList.remove('hidden')
+  el.portfolioProjects.classList.remove('section-invisible', 'hidden')
   el.portfolioProjects.classList.add('visible', 'content-section-reveal')
+
+  // Playground subsection lives inside the portfolio page now — reveal it too.
+  el.projects.classList.remove('section-invisible', 'hidden')
+  el.projects.classList.add('visible', 'content-section-reveal')
 
   if (event) trackClick(event)
 }

--- a/js/project-observer.js
+++ b/js/project-observer.js
@@ -12,7 +12,7 @@ export const PROJECT_CARD_INTERSECTION_THRESHOLD_STEPS = [0, 0.05, 0.1, 0.25, 0.
  *
  * @param {NodeList|Array} cards - project card elements to observe
  * @param {object} opts
- * @param {() => string} opts.getCurrentSection - returns 'playground' | 'portfolio' | other
+ * @param {() => string} opts.getCurrentSection - returns 'portfolio' or other
  * @param {(card: Element|null) => void} opts.onVisibleChange - called with the best card (or null)
  * @returns {{ recompute: () => void, disconnect: () => void }}
  */
@@ -24,11 +24,9 @@ export function initProjectObserver(cards, { getCurrentSection, onVisibleChange 
     let best = { ratio: 0, card: null }
     ratios.forEach((ratio, card) => {
       if (ratio > best.ratio) {
-        const section = card.closest('#playgroundContent')
-          ? 'playground'
-          : card.closest('#portfolioContent')
-            ? 'portfolio'
-            : null
+        // All project cards now live under #portfolioContent (portfolio cards
+        // proper + the playground subsection). One section, one match.
+        const section = card.closest('#portfolioContent') ? 'portfolio' : null
         if (section === getCurrentSection()) best = { ratio, card }
       }
     })

--- a/js/projects.js
+++ b/js/projects.js
@@ -157,11 +157,7 @@ export function initProjectDetailDialog() {
     const data = projectDetailsById.get(id);
     if (!data) return;
     dialog.setAttribute('data-project-id', id)
-    const section = window.location.hash === '#portfolio'
-      ? 'portfolio'
-      : window.location.hash === '#playground'
-        ? 'playground'
-        : 'home'
+    const section = window.location.hash === '#portfolio' ? 'portfolio' : 'home'
     trackProjectInteraction('open_details', id, section)
 
     lastFocus = document.activeElement;
@@ -237,9 +233,10 @@ export function initProjectDetailDialog() {
     openDialog(id);
   }
 
-  ['playgroundContent', 'portfolioContent'].forEach((cid) => {
-    const wrap = document.getElementById(cid);
-    if (!wrap) return;
+  // Both portfolio cards and playground subsection cards live inside
+  // #portfolioContent now, so a single delegate covers them.
+  const wrap = document.getElementById('portfolioContent');
+  if (wrap) {
     wrap.addEventListener('click', onActivateProject);
     wrap.addEventListener('keydown', (e) => {
       if (e.key !== 'Enter' && e.key !== ' ') return;
@@ -249,17 +246,13 @@ export function initProjectDetailDialog() {
       const id = card.getAttribute('data-project-id');
       if (id) openDialog(id);
     });
-  });
+  }
 
   closeBtn?.addEventListener('click', closeDialog);
   backdrop?.addEventListener('click', closeDialog);
   linkEl?.addEventListener('click', () => {
     const id = dialog.getAttribute('data-project-id') || ''
-    const section = window.location.hash === '#portfolio'
-      ? 'portfolio'
-      : window.location.hash === '#playground'
-        ? 'playground'
-        : 'home'
+    const section = window.location.hash === '#portfolio' ? 'portfolio' : 'home'
     trackProjectInteraction('open_link', id, section)
   })
 

--- a/js/section-names.js
+++ b/js/section-names.js
@@ -1,4 +1,7 @@
 /** Map navigation / UI section labels to chat + agent-node buckets. */
 export function normalizeSection(section) {
-  return section === 'playground' || section === 'portfolio' ? section : 'home'
+  // Legacy 'playground' bookmarks resolve to portfolio (playground is a
+  // subsection under portfolio now). Anything else is 'home'.
+  if (section === 'portfolio' || section === 'playground') return 'portfolio'
+  return 'home'
 }

--- a/js/spaceman-position.js
+++ b/js/spaceman-position.js
@@ -113,14 +113,10 @@ class SpacemanPosition {
     this._hooks = { ...this._hooks, ...hooks };
   }
 
-  /** Keep `body.content-open` in sync with visible playground/portfolio (hero CSS) even when `isStaying` skips layout `_update`. */
+  /** Keep `body.content-open` in sync with visible portfolio (hero CSS) even when `isStaying` skips layout `_update`. */
   _syncBodyContentOpen() {
-    const pg = document.getElementById('playgroundContent');
     const pf = document.getElementById('portfolioContent');
     const wrapperOpen =
-      !!(pg &&
-        pg.classList.contains('visible') &&
-        !pg.classList.contains('hidden')) ||
       !!(pf &&
         pf.classList.contains('visible') &&
         !pf.classList.contains('hidden'));
@@ -188,15 +184,15 @@ class SpacemanPosition {
       { id: 'contactDialog', panelSelector: '.contact-dialog__panel' }
     ];
     const contentEls = [
-      document.getElementById('playgroundContent'),
       document.getElementById('portfolioContent'),
       document.getElementById('projects'),
       document.getElementById('portfolioProjects')
     ].filter(Boolean);
 
-    // Class changes -> reposition
+    // Class changes -> reposition (only the top-level portfolio wrapper toggles
+    // hidden/visible; the inner sections are static once revealed).
     this._mutationObs = new MutationObserver(() => this.updatePosition());
-    contentEls.slice(0, 2).forEach(el => {
+    contentEls.slice(0, 1).forEach(el => {
       this._mutationObs.observe(el, { attributes: true, attributeFilter: ['class'] });
     });
     dialogs
@@ -741,7 +737,8 @@ class SpacemanPosition {
       return (rect.width > 0 && rect.height > 0) ? rect : null;
     };
 
-    return check('playgroundContent', 'projects') || check('portfolioContent', 'portfolioProjects');
+    // Portfolio holds both the professional cards and the playground subsection.
+    return check('portfolioContent', 'portfolioProjects') || check('portfolioContent', 'projects');
   }
 
   _calcPosition(vw, vh, content, scale) {

--- a/js/spaceman-project-context.js
+++ b/js/spaceman-project-context.js
@@ -16,7 +16,7 @@ export function initSpacemanProjectContext({
   spaceman,
   spacemanPosition
 }) {
-  const projectCards = document.querySelectorAll('#playgroundContent .project, #portfolioContent .project')
+  const projectCards = document.querySelectorAll('#portfolioContent .project')
   const projectObserver = initProjectObserver(projectCards, {
     getCurrentSection,
     onVisibleChange: (card) => {


### PR DESCRIPTION
Collapse the standalone Playground page into a subsection at the bottom of the Portfolio page. One nav link, one content page. Legacy '#playground' bookmarks redirect to portfolio.