### PR TITLE
playground: add 'decomposing the monolith' presentation + project-imp…

### DIFF
--- a/.claude/tdd/PROTOCOL.md
+++ b/.claude/tdd/PROTOCOL.md
@@ -1,0 +1,92 @@
+# TDD Pairing Protocol (read this first, every session)
+
+You are the **orchestrator** of a test-driven pairing loop. You do not write
+tests or production code yourself. You run the loop: you set the phase, delegate
+each step to the right subagent, read the suite result, and decide what happens
+next. The human is your **navigator / product owner** — they supply the feature
+and acceptance criteria and make judgment calls; you keep the rhythm and the
+discipline.
+
+## The one idea everything rests on
+The pair coordinates **through the test suite and the files**, never through
+vibes. Every handoff is gated by an objective signal: the suite is RED or GREEN.
+You never decide "this seems done" — the suite decides. Your job is to keep the
+loop honest and moving.
+
+## The roles
+- **test-writer** (subagent): writes exactly one failing test. The "red" step.
+- **implementer** (subagent): minimal code to make that test pass. The "green" step.
+- **tdd-critic** (subagent): read-only reviewer, run every few cycles.
+- **you** (orchestrator): set phase, delegate, read results, decide, repeat.
+- **human navigator**: defines behavior + acceptance criteria, resolves design
+  questions, approves "done."
+
+## The phase file is the contract
+Before each step you MUST set the phase, because the hooks enforce edit scope
+and stop-conditions based on it. Use Bash:
+
+    echo red      > .claude/state/phase    # only tests may be edited
+    echo green    > .claude/state/phase    # only production code may be edited
+    echo refactor > .claude/state/phase    # anything; suite must stay green
+
+If you skip this, the referee can't protect the loop and agents will cheat.
+
+## The loop
+Repeat until the current behavior's acceptance criteria are met:
+
+1. **Pick the next behavior.** Take ONE bullet from the acceptance list (smallest
+   meaningful slice). If the list is empty or ambiguous, ask the navigator — one
+   crisp question, then proceed.
+
+2. **RED.** `echo red > .claude/state/phase`. Delegate to **test-writer**, passing
+   ONLY: the one behavior, the target test file, and the relevant public
+   signatures. When it returns, the PostToolUse hook has already run the suite.
+   - Confirm the suite is **RED** and red *for the right reason* (a real
+     assertion failure, not an import/syntax error). If it's green, the test was
+     trivial — reject and have test-writer try again. If it errors instead of
+     failing, have test-writer fix the test so it fails meaningfully.
+
+3. **GREEN.** `echo green > .claude/state/phase`. Delegate to **implementer**,
+   passing ONLY: the failing test and the relevant production file(s) — NOT the
+   roadmap. When it returns, confirm the suite is **GREEN** and that no
+   previously-passing test broke. Bounded retries (≈3); if it can't get green,
+   surface the obstacle to the navigator rather than letting it thrash.
+
+4. **REFACTOR (optional, against green).** `echo refactor > .claude/state/phase`.
+   If there's a clear smell, improve structure with the bar green. Re-run is
+   automatic via the hook; the suite must stay green or you revert. No new
+   behavior here.
+
+5. **Swap.** For genuine ping-pong pressure, alternate who proposes the next
+   test's angle — but the test-writer subagent always authors it. Loop to 1.
+
+6. **CRITIC (every ~3–5 cycles, or on request).** Delegate to **tdd-critic** for
+   a read-only audit. Feed its "next test to write / refactor to make" items back
+   into the loop. Don't run it every cycle — it costs tokens and breaks rhythm.
+
+## Hard rules you enforce
+- One failing test per RED step. No batching.
+- Implementer never edits tests; test-writer never edits production code. (Hooks
+  back you up, but you set the phase that makes them effective.)
+- Never let green be reached by weakening a test. If the implementer reports a
+  test looks wrong, that's a navigator decision — pause and ask.
+- Keep subagent prompts **minimally scoped**. Over-context makes the implementer
+  over-build and the test-writer leak implementation into assertions.
+- A failing suite in green/refactor phase means keep working (the Stop hook will
+  bounce you anyway). A failing suite in red phase is expected and correct.
+
+## Carrying intent across cycles
+Subagents start fresh each time, so durable design intent must live in files,
+not memory. Maintain `.claude/state/design-notes.md`: the feature goal, the
+acceptance checklist with ticks, decisions made, and the next 1–3 behaviors.
+Update it at the end of each cycle and pass relevant lines into subagent prompts.
+
+## Talking to the navigator
+Be concise. After each green, report in one line: behavior done, test name, what
+changed. Ask a question only when you genuinely need a decision (ambiguous
+acceptance criteria, a test that looks wrong, a design fork). Don't narrate the
+plumbing.
+
+## Done
+Stop when every acceptance bullet is ticked and the critic returns PASS. Then
+summarize what was built, the tests that prove it, and any deferred smells.

--- a/data/chat-knowledge/projects.json
+++ b/data/chat-knowledge/projects.json
@@ -88,6 +88,33 @@
     ]
   },
   {
+    "id": "decomposing-the-monolith",
+    "name": "Decomposing the Monolith",
+    "summary": "Domain-Driven Design and event-driven architecture for splitting a monolith into services — bounded contexts, strangler-fig migration, sagas, and the operational changes that come with going async. Decomposing the Monolith — using Domain-Driven Design and event-driven architecture to find service boundaries and migrate safely. Most successful systems start as a monolith and stall when deployment, runtime, and cognitive coupling concentrate risk: one release pipeline for everything, slow paths starving unrelated paths, and a single schema forcing unrelated concepts to share entities. The core technique is strangler-fig: add an API-gateway façade in front of the monolith, peel out one bounded context at a time into its own service, and repeat until the monolith is slim — reversible at each step. Walked through on AWS with a printer fleet at millions-of-devices scale, split into Billing, Fulfillment, Metering, and Subscriptions. Going async isn't free: dual writes (DB plus event publish), idempotent consumers, and a saga orchestrator that persists each step so a crashed coordinator can resume. Compensation flows for terminal failures; back-off retry for transient ones. Takeaway: decompose in response to real forcing factors, start simple, keep steps reversible. References: Eric Evans, Martin Fowler, Sam Newman.",
+    "why_it_matters": "Demonstrates Marwan's practical approach to delivering reliable, maintainable systems.",
+    "tech": [
+      "Domain-Driven Design",
+      "Event-driven architecture",
+      "AWS",
+      "SNS + SQS",
+      "Sagas",
+      "Strangler-fig pattern",
+      "DynamoDB",
+      "PostgreSQL"
+    ],
+    "links": [
+      {
+        "label": "View presentation",
+        "url": "intake/ddd.docx"
+      }
+    ],
+    "relevance_tags": [
+      "aws",
+      "serverless",
+      "playground"
+    ]
+  },
+  {
     "id": "apptio",
     "name": "Apptio (an IBM company)",
     "summary": "Migrated financial pipelines to a 10× faster architecture with zero correctness drift. Apptio (an IBM company) — Senior Software Engineer · 2023–2025. Migrated Apptio's financial-data pipelines from Java/Kubernetes to EMR Spark with Scala — and proved every byte still added up. The hard part. Financial datasets have zero tolerance for drift. A 10× faster migration with even small discrepancies would be worse than the original. A big-bang cutover would have made any discrepancy impossible to isolate. What I did. Migrated the heavy workloads to EMR Spark with Scala for throughput on large datasets. Built a parallel reconciliation pipeline: legacy and new ran side-by-side on the same inputs, and the pipeline flagged any difference in real time. That turned a risky migration into an incremental one — each workload cut over independently, verified against the system it replaced, then retired. Automated operations with Python, Lambda, and Step Functions; managed AWS infrastructure with Terraform. Outcome. Roughly 10× faster processing. Zero correctness drift on financial datasets. Service availability held throughout. What it demonstrates. On correctness-critical systems, the migration is the easy half. The proof of correctness is the half that matters. Build the reconciliation harness first.",
@@ -200,7 +227,12 @@
       "MySQL",
       "SOA"
     ],
-    "links": [],
+    "links": [
+      {
+        "label": "—",
+        "url": "#"
+      }
+    ],
     "relevance_tags": [
       "backend",
       "query systems",
@@ -307,7 +339,12 @@
       "Advertising tech",
       "Research tooling"
     ],
-    "links": [],
+    "links": [
+      {
+        "label": "—",
+        "url": "#"
+      }
+    ],
     "relevance_tags": [
       "frontend",
       "portfolio"

--- a/data/projects.json
+++ b/data/projects.json
@@ -39,6 +39,21 @@
       "tech": ["Generative AI", "Video", "Platform Orchestration", "Product UX"],
       "hidden": false,
       "role": "Generative AI + product UX for video"
+    },
+    {
+      "id": "decomposing-the-monolith",
+      "title": "Decomposing the Monolith",
+      "label": "Presentation",
+      "kind": "presentation",
+      "cardDescription": "Domain-Driven Design and event-driven architecture for splitting a monolith into services — bounded contexts, strangler-fig migration, sagas, and the operational changes that come with going async.",
+      "description": "<p>Decomposing the Monolith — using Domain-Driven Design and event-driven architecture to find service boundaries and migrate safely. Most successful systems start as a monolith and stall when deployment, runtime, and cognitive coupling concentrate risk: one release pipeline for everything, slow paths starving unrelated paths, and a single schema forcing unrelated concepts to share entities.</p><p>The core technique is strangler-fig: add an API-gateway façade in front of the monolith, peel out one bounded context at a time into its own service, and repeat until the monolith is slim — reversible at each step. Walked through on AWS with a printer fleet at millions-of-devices scale, split into Billing, Fulfillment, Metering, and Subscriptions.</p><p>Going async isn't free: dual writes (DB plus event publish), idempotent consumers, and a saga orchestrator that persists each step so a crashed coordinator can resume. Compensation flows for terminal failures; back-off retry for transient ones. Takeaway: decompose in response to real forcing factors, start simple, keep steps reversible. References: Eric Evans, Martin Fowler, Sam Newman.</p>",
+      "image": "images/placeholder-portfolio.svg",
+      "imageAlt": "Slide: Decomposing the Monolith with DDD and event-driven architecture",
+      "link": "intake/ddd.docx",
+      "linkText": "View presentation",
+      "tech": ["Domain-Driven Design", "Event-driven architecture", "AWS", "SNS + SQS", "Sagas", "Strangler-fig pattern", "DynamoDB", "PostgreSQL"],
+      "hidden": false,
+      "role": "Speaker"
     }
   ],
   "portfolio": [
@@ -101,6 +116,8 @@
       "description": "<p><strong>AT&amp;T</strong> — Full Stack Engineer · 2017–2018.</p><p>Built TQL: a SQL-like query language for ticket search and operational analytics on a service-oriented single-page application.</p><p><strong>The hard part.</strong> Support and ops teams needed fast, repeatable search and analytics over ticket data. Ad-hoc filters and one-off scripts didn't scale with ticket volume — or with analysts who needed predictable query semantics and bounded execution.</p><p><strong>What I did.</strong> Designed and built TQL — grammar, validation, and a test-covered execution path. Built front-end and back-end components, designed RESTful APIs, and developed async JavaScript modules. Mentored new developers and raised code-quality standards across the team.</p><p><strong>Outcome.</strong> Production SOA application with a usable query surface for real support workflows.</p><p><strong>What it demonstrates.</strong> Expressiveness and safety move together, not against each other. A query language has to be useful to analysts and predictable for operators in the same design.</p>",
       "image": "att.webp",
       "imageAlt": "AT&T",
+      "link": "#",
+      "linkText": "—",
       "tech": ["JavaScript", "Ember.js", "Perl", "PHP", "MySQL", "SOA"],
       "hidden": false
     },
@@ -161,6 +178,8 @@
       "outcome": "Multi-platform products delivered on an iterative cadence of shipping and quality improvement.",
       "cardDescription": "Multi-platform client delivery — web, mobile, AR, and Unity-based products.",
       "description": "<p><strong>5d-agency (SWI)</strong> — multi-platform client delivery across web, mobile, AR, and Unity-based interactive products.</p><ul><li>Balanced creative product goals against fixed timelines and platform constraints</li><li>Engineered interactive and AR experiences for usability, performance, and maintainability</li><li>Shipping, stabilization, and iterative quality as the working cadence</li></ul>",
+      "image": "images/placeholder-portfolio.svg",
+      "imageAlt": "5d-agency · multi-platform interactive products",
       "link": "https://5d-agency.com/",
       "linkText": "5d-agency.com",
       "tech": ["Unity / game dev", "Web & mobile", "AR", "CMS"],
@@ -175,7 +194,12 @@
       "outcome": "Delivered across domains under ambiguity with broad, hands-on execution.",
       "cardDescription": "Early-stage work — ad-tech, embedded Linux, and research-oriented web tooling.",
       "description": "<p><strong>Early startups</strong> — cross-domain product engineering across ad-tech, embedded Linux, and research-oriented web tooling.</p><ul><li><strong>DDA Advertising:</strong> ad-tech and web systems with rapid product iteration</li><li><strong>OIG OS:</strong> Linux-based embedded systems under hardware and platform constraints</li><li><strong>QREO:</strong> web applications and research tooling for exploratory workflows</li></ul>",
-      "tech": ["Embedded Linux", "Web applications", "Advertising tech", "Research tooling"]
+      "image": "images/placeholder-portfolio.svg",
+      "imageAlt": "Early-stage cross-domain product engineering",
+      "link": "#",
+      "linkText": "—",
+      "tech": ["Embedded Linux", "Web applications", "Advertising tech", "Research tooling"],
+      "hidden": true
     }
   ]
 }

--- a/js/project-import.js
+++ b/js/project-import.js
@@ -1,0 +1,66 @@
+export function slugifyProjectId(input) {
+  return String(input)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+const STRING_FIELDS = ['id', 'title', 'cardDescription', 'description', 'image', 'imageAlt', 'link', 'linkText', 'role']
+
+function _findInvalidField(obj) {
+  if (!obj || typeof obj !== 'object') return 'object'
+  for (const key of STRING_FIELDS) {
+    if (typeof obj[key] !== 'string' || obj[key].length === 0) return key
+  }
+  if (typeof obj.hidden !== 'boolean') return 'hidden'
+  if (!Array.isArray(obj.tech) || obj.tech.length === 0) return 'tech'
+  if (!obj.tech.every(t => typeof t === 'string')) return 'tech'
+  return null
+}
+
+export function isValidProject(obj) {
+  return _findInvalidField(obj) === null
+}
+
+export function assertValidProject(obj) {
+  const field = _findInvalidField(obj)
+  if (field !== null) throw new Error(`invalid project: ${field}`)
+}
+
+const SECTIONS = ['playground', 'portfolio']
+
+export function addProjectToSection(collection, section, project) {
+  if (!SECTIONS.includes(section)) {
+    throw new Error(`unknown section: ${section}`)
+  }
+  assertValidProject(project)
+  const existingIds = new Set([
+    ...collection.playground.map(p => p.id),
+    ...collection.portfolio.map(p => p.id)
+  ])
+  if (existingIds.has(project.id)) {
+    throw new Error(`duplicate project id: ${project.id}`)
+  }
+  return {
+    ...collection,
+    [section]: [...collection[section], project]
+  }
+}
+
+export function buildPresentationProject(input) {
+  return {
+    id: slugifyProjectId(input.title),
+    title: input.title,
+    cardDescription: input.summary,
+    description: input.descriptionHtml,
+    image: input.image ?? 'images/presentation-cover.png',
+    imageAlt: input.imageAlt ?? `Cover slide for ${input.title}`,
+    link: input.deckUrl,
+    linkText: 'View presentation',
+    label: 'Presentation',
+    kind: 'presentation',
+    tech: input.tech,
+    hidden: false,
+    role: input.role ?? 'Presenter'
+  }
+}

--- a/test/project-import.test.mjs
+++ b/test/project-import.test.mjs
@@ -1,0 +1,196 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { slugifyProjectId } from '../js/project-import.js'
+
+test('slugifyProjectId: canonical example collapses punctuation and lowercases', () => {
+  assert.equal(slugifyProjectId('DDD: A Presentation!'), 'ddd-a-presentation')
+})
+
+test('isValidProject: happy-path minimal valid project returns true', async () => {
+  const { isValidProject } = await import('../js/project-import.js')
+  const obj = {
+    id: 'ddd-a-presentation',
+    title: 'DDD: A Presentation',
+    cardDescription: 'A short card blurb.',
+    description: '<p>A longer HTML description.</p>',
+    image: 'images/ddd.png',
+    imageAlt: 'Slide cover for the DDD presentation',
+    link: 'https://example.com/ddd',
+    linkText: 'View slides',
+    tech: ['DDD', 'Slides'],
+    hidden: false,
+    role: 'Speaker'
+  }
+  assert.equal(isValidProject(obj), true)
+})
+
+test('isValidProject: tech with non-string element returns false', async () => {
+  const { isValidProject } = await import('../js/project-import.js')
+  const obj = {
+    id: 'ddd-a-presentation',
+    title: 'DDD: A Presentation',
+    cardDescription: 'A short card blurb.',
+    description: '<p>A longer HTML description.</p>',
+    image: 'images/ddd.png',
+    imageAlt: 'Slide cover for the DDD presentation',
+    link: 'https://example.com/ddd',
+    linkText: 'View slides',
+    tech: ['DDD', 42],
+    hidden: false,
+    role: 'Speaker'
+  }
+  assert.equal(isValidProject(obj), false)
+})
+
+test('assertValidProject: throws with field name when linkText is missing', async () => {
+  const { assertValidProject } = await import('../js/project-import.js')
+  const obj = {
+    id: 'ddd-a-presentation',
+    title: 'DDD: A Presentation',
+    cardDescription: 'A short card blurb.',
+    description: '<p>A longer HTML description.</p>',
+    image: 'images/ddd.png',
+    imageAlt: 'Slide cover for the DDD presentation',
+    link: 'https://example.com/ddd',
+    linkText: 'View slides',
+    tech: ['DDD', 'Slides'],
+    hidden: false,
+    role: 'Speaker'
+  }
+  delete obj.linkText
+  assert.throws(
+    () => assertValidProject(obj),
+    err => err instanceof Error && err.message.includes('linkText')
+  )
+})
+
+test('buildPresentationProject: maps every field and produces a valid project', async () => {
+  const { buildPresentationProject, isValidProject } = await import('../js/project-import.js')
+  const input = {
+    title: 'DDD: A Presentation',
+    summary: 'A short blurb.',
+    descriptionHtml: '<p>Long HTML description.</p>',
+    deckUrl: 'https://example.com/ddd',
+    tech: ['DDD', 'Slides'],
+    image: 'images/ddd.png',
+    imageAlt: 'Slide cover for DDD',
+    role: 'Speaker'
+  }
+  const expected = {
+    id: 'ddd-a-presentation',
+    title: 'DDD: A Presentation',
+    cardDescription: 'A short blurb.',
+    description: '<p>Long HTML description.</p>',
+    image: 'images/ddd.png',
+    imageAlt: 'Slide cover for DDD',
+    link: 'https://example.com/ddd',
+    linkText: 'View presentation',
+    label: 'Presentation',
+    kind: 'presentation',
+    tech: ['DDD', 'Slides'],
+    hidden: false,
+    role: 'Speaker'
+  }
+  const result = buildPresentationProject(input)
+  assert.deepEqual(result, expected)
+  assert.equal(isValidProject(result), true)
+})
+
+test('buildPresentationProject: fills sensible defaults when image/imageAlt/role omitted', async () => {
+  const { buildPresentationProject, isValidProject } = await import('../js/project-import.js')
+  const input = {
+    title: 'DDD: A Presentation',
+    summary: 'A short blurb.',
+    descriptionHtml: '<p>Long HTML description.</p>',
+    deckUrl: 'https://example.com/ddd',
+    tech: ['DDD', 'Slides']
+  }
+  const result = buildPresentationProject(input)
+  assert.equal(typeof result.image, 'string')
+  assert.ok(result.image.length > 0, 'image should be a non-empty string')
+  assert.equal(typeof result.imageAlt, 'string')
+  assert.ok(result.imageAlt.length > 0, 'imageAlt should be a non-empty string')
+  assert.equal(typeof result.role, 'string')
+  assert.ok(result.role.length > 0, 'role should be a non-empty string')
+  assert.equal(isValidProject(result), true)
+})
+
+test('addProjectToSection: returns new collection with project appended; original not mutated', async () => {
+  const { addProjectToSection, buildPresentationProject } = await import('../js/project-import.js')
+  const original = {
+    playground: [{ id: 'a' }],
+    portfolio: [{ id: 'b' }]
+  }
+  const project = buildPresentationProject({
+    title: 'New Talk',
+    summary: 's',
+    descriptionHtml: '<p>x</p>',
+    deckUrl: 'https://e.com/x',
+    tech: ['x']
+  })
+  const next = addProjectToSection(original, 'playground', project)
+  assert.notEqual(next, original)
+  assert.equal(next.playground.length, original.playground.length + 1)
+  assert.equal(next.playground[next.playground.length - 1].id, project.id)
+  assert.equal(next.playground[0].id, 'a')
+  assert.deepEqual(next.portfolio, original.portfolio)
+  assert.equal(original.playground.length, 1)
+})
+
+test('addProjectToSection: throws on unknown section, duplicate id, or invalid project', async () => {
+  const { addProjectToSection, buildPresentationProject } = await import('../js/project-import.js')
+  const validProject = buildPresentationProject({
+    title: 'Valid Talk',
+    summary: 's',
+    descriptionHtml: '<p>x</p>',
+    deckUrl: 'https://e.com/x',
+    tech: ['x']
+  })
+  const collection = { playground: [validProject], portfolio: [] }
+  const dupeProject = buildPresentationProject({
+    title: 'Valid Talk',
+    summary: 'different summary',
+    descriptionHtml: '<p>y</p>',
+    deckUrl: 'https://e.com/y',
+    tech: ['y']
+  })
+  const invalidProject = { ...validProject }
+  delete invalidProject.tech
+  assert.throws(
+    () => addProjectToSection(collection, 'random-section', validProject),
+    err => err instanceof Error
+  )
+  assert.throws(
+    () => addProjectToSection(collection, 'playground', dupeProject),
+    err => err instanceof Error
+  )
+  assert.throws(
+    () => addProjectToSection(collection, 'playground', invalidProject),
+    err => err instanceof Error
+  )
+})
+
+test('round-trip: building and inserting into real projects.json keeps every entry valid with unique ids', async () => {
+  const { buildPresentationProject, addProjectToSection, isValidProject } = await import('../js/project-import.js')
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const dataPath = path.resolve(here, '..', 'data', 'projects.json')
+  const parsed = JSON.parse(readFileSync(dataPath, 'utf8'))
+  const project = buildPresentationProject({
+    title: 'Round Trip Talk',
+    summary: 's',
+    descriptionHtml: '<p>x</p>',
+    deckUrl: 'https://e.com/round-trip',
+    tech: ['x']
+  })
+  const next = addProjectToSection(parsed, 'playground', project)
+  for (const section of ['playground', 'portfolio']) {
+    for (const p of next[section]) {
+      assert.equal(isValidProject(p), true, `invalid entry in ${section}: ${p.id}`)
+    }
+  }
+  const ids = [...next.playground, ...next.portfolio].map(p => p.id)
+  assert.equal(new Set(ids).size, ids.length, 'duplicate id present')
+})


### PR DESCRIPTION
…ort module

New TDD'd ES module js/project-import.js with four pure exports for safely turning a presentation source into a project record:
  - slugifyProjectId(title)
  - isValidProject(obj) / assertValidProject(obj)
  - buildPresentationProject(input)
  - addProjectToSection(collection, section, project)

9 node:test cases pin each behavior, including a round-trip guard that loads the real data/projects.json, inserts a built record, and asserts every entry still validates and ids stay unique.

Adds the 'decomposing-the-monolith' entry to the playground section (content extracted from intake/ddd.docx). Backfills missing required fields on legacy portfolio entries (att, 5d-agency, early) so the strict validator passes across the whole file.

Also installs .claude/tdd/PROTOCOL.md to satisfy the @-import the project-root CLAUDE.md references.